### PR TITLE
Kirk and Team - Premier Ticket fixed issue

### DIFF
--- a/Enterprise/using-azure-ad-for-sharepoint-server-authentication.md
+++ b/Enterprise/using-azure-ad-for-sharepoint-server-authentication.md
@@ -132,11 +132,12 @@ $wsfedurl="<SAML single sign-on service URL from Table 1>"
 $filepath="<Full path to SAML signing certificate file from Table 1>"
 $cert = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2($filepath)
 New-SPTrustedRootAuthority -Name "AzureAD" -Certificate $cert
-$map = New-SPClaimTypeMapping -IncomingClaimType "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name" -IncomingClaimTypeDisplayName "name" -LocalClaimType "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/upn"
+$map = New-SPClaimTypeMapping -IncomingClaimType "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name" -IncomingClaimTypeDisplayName "name" -LocalClaimType "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress"
 $map2 = New-SPClaimTypeMapping -IncomingClaimType "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname" -IncomingClaimTypeDisplayName "GivenName" -SameAsIncoming
 $map3 = New-SPClaimTypeMapping -IncomingClaimType "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname" -IncomingClaimTypeDisplayName "SurName" -SameAsIncoming
-$map4 = New-SPClaimTypeMapping -IncomingClaimType "http://schemas.microsoft.com/ws/2008/06/identity/claims/role" -IncomingClaimTypeDisplayName "Groups" -SameAsIncoming
-$ap = New-SPTrustedIdentityTokenIssuer -Name "AzureAD" -Description "SharePoint secured by Azure AD" -realm $realm -ImportTrustCertificate $cert -ClaimsMappings $map,$map2,$map3,$map4 -SignInUrl $wsfedurl -IdentifierClaim "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name"
+$map4 = New-SPClaimTypeMapping -IncomingClaimType "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/upn" -IncomingClaimTypeDisplayName "upn" -SameAsIncoming
+$map5 = New-SPClaimTypeMapping -IncomingClaimType "http://schemas.microsoft.com/ws/2008/06/identity/claims/role" -IncomingClaimTypeDisplayName "Groups" -SameAsIncoming
+$ap = New-SPTrustedIdentityTokenIssuer -Name "AzureAD" -Description "SharePoint secured by Azure AD" -ImportTrustCertificate $cert  -realm $realm -ClaimsMappings $map,$map2,$map3,$map4,$map5 -SignInUrl $wsfedurl -IdentifierClaim "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name"
 ```
 
 Next, follow these steps to enable the trusted identity provider for your application:
@@ -235,6 +236,15 @@ Users can now log into SharePoint 2016 using identities from Azure AD, but there
 There is no validation on the values you search for, which can lead to misspellings or users accidentally choosing the wrong claim type to assign such as the **SurName** claim. This can prevent users from successfully accessing resources.
 
 To assist with this scenario, there is an open-source solution called [AzureCP](https://yvand.github.io/AzureCP/) that provides a custom claims provider for SharePoint 2016. It will use the Azure AD Graph to resolve what users enter and perform validation. Learn more at [AzureCP](https://yvand.github.io/AzureCP/). 
+
+## Robert "Moojjoo" Dannelly Notes from MSFT Premier Ticket
+1.	Associate the AzureAD trusted identity token issuer to the appropriate web application and zone
+2.	Configure AzureCP 
+a.	Remove the default Mail claim mapping
+b.	Change the property to look users up by for the email address claim from UPN to Mail. 
+i.	Display the mail property and set the picker entity type to Email
+3.	Configure the Claim configuration in AzureAD for your On-premises App to use the Mail property as the Name claim and format for the nameidentifier
+
 
 ## Additional resources
 


### PR DESCRIPTION
Just wanted to share that there is an issue using UPN because of the way the UPN is passed by Azure.  For guest with emails like name@gmail.com come as name_gmail.com#EXT#@tenant.onmicrosoft.com.  However, if it is for a user who belogs to another tenant the UPN will come as just the email name@domain.com and the name picker will not correctly reconcile the UPN.   We opened a premier ticket with MSFT and got a Level III Engineer and I want to share a solution that could help many of your customers.    I edited the document above and will branch and send a pull, however there are also some changes in the Azure Single Sign On and Azure CP.   They will be at the bottom of the branch.

Summery of Resolution:
Issue Summary
==============
We have a custom enterprise application for SharePoint 2016, which has "Unique User Identifier" set to "user.userprincipalname" (default configuration), but the experience with Guest accounts is bad: 
- MSA Guest accounts identity set by AAD looks like "user_mail.com#EXT#@Tenant.onmicrosoft.com", which is counter intuitive. When granting permissions to those accounts in SharePoint, we expect to type UserUPN@Tenant.onmicrosoft.com, not user_mail.com#EXT#@Tenant.onmicrosoft.com 
- B2B Guest accounts identity set by AAD looks like "mail@Tenant.onmicrosoft.com", which is great and what we want, but it's inconsistent with the MSA Guest accounts and causes a lot of confusion.
 
Cause:
==============
This issue is by design and is how every "Guest" account's UPN is represented in Azure AD.  However that is not the same UPN value that is passed for every "Guest" account type.
Guest Account Types:
Microsoft Account - This is your gmail, Yahoo, etc.. Users
This "Guest" account will send the UPN as user_mail.com#EXT#@Tenant.onmicrosoft.com
External Azure Active Directory - Users who belong to an external AzureAD Tenant
This "Guest" account authenticates outside our Azure Tenant so the claim value for the UPN is in normal notation of user@tenant.onmicrosoft.com
 
AzureCP Claim provider will lookup "Guest" account using a known claim (UPN/Email).  The problem is that it doesn't differentiate between the two different "Guest" accounts.
So either one type of "Guest" account works or the other one does, but not both.
 
Resolution:
==============
Long story short: 
We switch to using the "Email Address" claim as the identifying claim and the value of the "Name" claim sent from Azure AD
This allowed all "Guest" users regardless of the type of "Guest" user they are will be looked up and authenticated by their "Email" address claim
This also gives us a straight forward migration route from Okta to AzureAD
 
Long Story Longer:
Here is the process start to finish including PS scripts.
 
1.	Remove AzureAD identity provider from your web applications for all zones it’s assigned to
2.	Remove your AzureAD trusted identity token issuer and associated Cert from the trusted root authority store
3.	Remove the AzureCP Claim provider
 
Remove-SPTrustedIdentityTokenIssuer -Identity "AzureAD"
Remove-SPTrustedRootAuthority "AzureAD"
Remove-SPClaimProvider "AzureCP" 
 
1.	Disable the AzureCP feature
2.	Uninstall the AzureCP solution
3.	Remove the AzureCP solution form the farm
 
Disable-SPFeature -identity "AzureCP"
Uninstall-SPSolution -Identity "AzureCP.wsp"
# Wait for the timer job to complete before running Remove-SPSolution
Remove-SPSolution -Identity "AzureCP.wsp" 
 
1.	Re-create the AzureAD trusted identity token issuer via PS
$realm = "https://projects-ext-uat.piedmontng.com/"
$wsfedurl="https://login.microsoftonline.com/fc961150-c46c-44fd-8992-3aa617016257/wsfed"
$filepath="C:/_cert/UAT_Projects.cer"
$cert = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2($filepath)
New-SPTrustedRootAuthority -Name "AzureAD" -Certificate $cert
$map = New-SPClaimTypeMapping -IncomingClaimType "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name" -IncomingClaimTypeDisplayName "name" -LocalClaimType "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress"
$map2 = New-SPClaimTypeMapping -IncomingClaimType "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname" -IncomingClaimTypeDisplayName "GivenName" -SameAsIncoming
$map3 = New-SPClaimTypeMapping -IncomingClaimType "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname" -IncomingClaimTypeDisplayName "SurName" -SameAsIncoming
$map4 = New-SPClaimTypeMapping -IncomingClaimType "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/upn" -IncomingClaimTypeDisplayName "upn" -SameAsIncoming
$map5 = New-SPClaimTypeMapping -IncomingClaimType "http://schemas.microsoft.com/ws/2008/06/identity/claims/role" -IncomingClaimTypeDisplayName "Groups" -SameAsIncoming
$ap = New-SPTrustedIdentityTokenIssuer -Name "AzureAD" -Description "SharePoint secured by Azure AD" -ImportTrustCertificate $cert  -realm $realm -ClaimsMappings $map,$map2,$map3,$map4,$map5 -SignInUrl $wsfedurl -IdentifierClaim "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name"
 
1.	Re-create the AzureCP Claim Provider and associate it with the AzureAD trusted identity provider (change the ‘-LiteralPath’ to match your environment)
 
Add-SPSolution -LiteralPath "C:\AzureCP.wsp"
Install-SPSolution -Identity "AzureCP.wsp" -GACDeployment
#Wait for Solution to Install before associating it with a SPTrustedIdentityTokenIssuer 
#Associate AzureCP with a SPTrustedIdentityTokenIssuer:
$trust = Get-SPTrustedIdentityTokenIssuer "AzureAD"
$trust.ClaimProviderName = "AzureCP"
$trust.Update() 
 
1.	Associate the AzureAD trusted identity token issuer to the appropriate web application and zone
2.	Configure AzureCP 
a.	Remove the default Mail claim mapping
b.	Change the property to look users up by for the email address claim from UPN to Mail. 
i.	Display the mail property and set the picker entity type to Email
3.	Configure the Claim configuration in AzureAD for your On-premises App to use the Mail property as the Name claim and format for the nameidentifier

Thanks,
Brent Person
Microsoft SharePoint Technologies 
Support Escalation Engineer